### PR TITLE
Generalized reachability to better work for non-quadrupedal robots

### DIFF
--- a/art_planner/include/art_planner/params.h
+++ b/art_planner/include/art_planner/params.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <string>
 #include <cmath>
 #include <memory>
+#include <string>
+#include <vector>
 
 
 
@@ -76,6 +77,7 @@ struct Params {
   } objectives;
 
   struct {
+    bool           align_torso_with_terrain{true};
     double         max_pitch_pert{10.0 / 180*M_PI};
     double         max_roll_pert{3.33 / 180*M_PI};
     bool           sample_from_distribution{true};
@@ -101,6 +103,9 @@ struct Params {
     } torso;
 
     struct {
+
+      std::vector<std::string> plane_symmetries{"sagittal",
+                                                "coronal"};
 
       struct {
         double         x{0.362};

--- a/art_planner/include/art_planner/validity_checker/validity_checker_feet.h
+++ b/art_planner/include/art_planner/validity_checker/validity_checker_feet.h
@@ -29,6 +29,7 @@ class ValidityCheckerFeet {
 
   float box_length_;
   float box_width_;
+  std::vector<Pose3> box_centers_;
 
   bool boxIsValidAtPose(const Pose3& pose) const;
 

--- a/art_planner/src/sampler.cpp
+++ b/art_planner/src/sampler.cpp
@@ -98,7 +98,12 @@ void SE3FromSE2Sampler::sampleUniform(ob::State* state) {
   state_pos_.get()->values[2] = map_->getHeightAtIndex(ind);
 
   // Apply small random perturbation in normal direction.
-  const Eigen::Vector3d normal_w = map_->getNormal(ind);
+  Eigen::Vector3d normal_w;
+  if (params_->sampler.align_torso_with_terrain) {
+    normal_w = map_->getNormal(ind);
+  } else {
+    normal_w = Eigen::Vector3d::UnitZ();
+  }
 
   const auto std = map_->getPlaneFitStdDev(ind);
 

--- a/art_planner_ros/config/params.yaml
+++ b/art_planner_ros/config/params.yaml
@@ -42,7 +42,8 @@ objectives:                                         # Not active with prm_motion
         max_lat_vel: 0.1                            # [m/s]   Maximal lateral velocitiy.
         max_ang_vel: 0.5                            # [rad/s] Maximal angular velocity.
 
-sampler:        
+sampler:
+    align_torso_with_terrain: false                 # Align sampled pose with terrain normal.
     max_pitch_pert: 10                              # [degree]  Maximum pitch pertubation when sampling.
     max_roll_pert: 3.33                             # [degree]  Maximum roll pertubation when sampling.
     sample_from_distribution: true                  # Whether to use our custom sampling distribution or sample uniformly in the map.
@@ -61,11 +62,12 @@ robot:
             y: 0.0
             z: 0.04
     feet:
+        plane_symmetries: ["sagittal","coronal"]    # Body planes on which to mirror reachability box. Options: 'sagittal' - left/right, 'coronal' - front/back.
         offset:                                     # [m] Reachability box offset relative to base_frame.
-            x: 0.51                                # Sign of value does not matter.
-            y: 0.2                                # Sign of value does not matter.
+            x: 0.51
+            y: 0.2
             z: -0.475
-        reach:                                      # [m] Reachability of foot box size.
+        reach:                                      # [m] Reachability of foot (box size).
             x: 0.2
             y: 0.2
             z: 0.2

--- a/art_planner_ros/include/art_planner_ros/utils.h
+++ b/art_planner_ros/include/art_planner_ros/utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include <art_planner/params.h>
 #include <ros/node_handle.h>
@@ -25,11 +26,55 @@ inline T getParamWithDefaultWarning(const ros::NodeHandle& nh,
   return param;
 }
 
+// Specialize for unsigned int.
 template <>
-inline unsigned int getParamWithDefaultWarning<unsigned int>(const ros::NodeHandle& nh,
-                                                      const std::string& name,
-                                                      const unsigned int& default_val) {
+inline unsigned int getParamWithDefaultWarning<unsigned int>(
+                      const ros::NodeHandle& nh,
+                      const std::string& name,
+                      const unsigned int& default_val) {
   return getParamWithDefaultWarning(nh, name, static_cast<int>(default_val));
+}
+
+// Overload for std::vector.
+template <typename T>
+inline std::vector<T> getParamWithDefaultWarning(
+                        const ros::NodeHandle& nh,
+                        const std::string& name,
+                        const std::vector<T>& default_val) {
+  std::vector<T> param;
+
+  if (!nh.param(name, param, default_val)) {
+    std::string default_string;
+    for (size_t i = 0; i < default_val.size(); ++i) {
+      if (i > 0) default_string += std::string(", ");
+      default_string += std::to_string(default_val[i]);
+    }
+    ROS_WARN_STREAM("Could not find ROS param \"" << name <<
+                    "\", set to default: [" << default_string << "]");
+  }
+
+  return param;
+}
+
+// Specialize for std::vector of std::string.
+template <>
+inline std::vector<std::string> getParamWithDefaultWarning(
+                        const ros::NodeHandle& nh,
+                        const std::string& name,
+                        const std::vector<std::string>& default_val) {
+  std::vector<std::string> param;
+
+  if (!nh.param(name, param, default_val)) {
+    std::string default_string;
+    for (size_t i = 0; i < default_val.size(); ++i) {
+      if (i > 0) default_string += std::string(", ");
+      default_string += default_val[i];
+    }
+    ROS_WARN_STREAM("Could not find ROS param \"" << name <<
+                    "\", set to default: [" << default_string << "]");
+  }
+
+  return param;
 }
 
 

--- a/art_planner_ros/src/utils.cpp
+++ b/art_planner_ros/src/utils.cpp
@@ -178,6 +178,10 @@ ParamsPtr art_planner::loadRosParameters(const ros::NodeHandle& nh) {
 
   // Sampler.
 
+  params->sampler.align_torso_with_terrain =
+      getParamWithDefaultWarning(nh,
+                                 "sampler/align_torso_with_terrain",
+                                 params->sampler.align_torso_with_terrain);
   params->sampler.max_pitch_pert =
       getParamWithDefaultWarning(nh,
                                  "sampler/max_pitch_pert",
@@ -242,6 +246,13 @@ ParamsPtr art_planner::loadRosParameters(const ros::NodeHandle& nh) {
       getParamWithDefaultWarning(nh,
                                  "robot/torso/offset/z",
                                  params->robot.torso.offset.z);
+
+  // Robot / Feet.
+
+  params->robot.feet.plane_symmetries =
+      getParamWithDefaultWarning(nh,
+                                 "robot/feet/plane_symmetries",
+                                 params->robot.feet.plane_symmetries);
 
   // Robot / Feet / Offset.
 


### PR DESCRIPTION
Reachability boxes are now specified with planes of symmetries, which allows to easily use bipedal configurations, for example.
Also added a parameter to disable alignment of sampled poses with the terrain, which might not make sense for all robot types.

Works for bipedal mockup:
![Screenshot from 2023-03-03 19-56-47](https://user-images.githubusercontent.com/5803027/222805827-c1ca79bc-87e5-4ad1-b81f-10904cc6337c.png)

This PR touches performance-relevant parts of the code. I still need to make sure nothing got worse before I merge to main.